### PR TITLE
repos: bluerobotics: Update cockpit remote

### DIFF
--- a/repos/bluerobotics/cockpit/metadata.json
+++ b/repos/bluerobotics/cockpit/metadata.json
@@ -1,6 +1,6 @@
 {
     "name": "Cockpit",
     "website": "https://github.com/bluerobotics/cockpit",
-    "docker": "patrickelectric/cockpit",
+    "docker": "bluerobotics/cockpit",
     "description": "In development, use it at your own risk ."
 }


### PR DESCRIPTION
With the CI added, now we have tags available on bluerobotics official remote
https://hub.docker.com/r/bluerobotics/cockpit/tags