### PR TITLE
 consolidate.py to work with venv

### DIFF
--- a/blueos_repository/consolidate.py
+++ b/blueos_repository/consolidate.py
@@ -78,7 +78,7 @@ class Consolidator:
 
     @staticmethod
     def repo_folder() -> Path:
-        return Path(__file__).parent.parent
+        return Path(__file__).parent.parent.joinpath("repos")
 
     @staticmethod
     async def fetch_readme(url: str) -> str:
@@ -123,7 +123,7 @@ class Consolidator:
                     )
                     yield new_repo
                 except Exception as error:
-                    raise Exception(f"unable to read file {individual_file}: {error}") from error
+                    raise Exception(f"unable to read file {repo}: {error}") from error
 
     @staticmethod
     def is_valid_semver(string: str) -> bool:


### PR DESCRIPTION
 * Modified consolidate.py to only search in repos/ folder. python virtual environments also create a file called metadata.json. which causes issues
 * filepath instead of object in exception printing