### PR TITLE
Rusty website improvements

### DIFF
--- a/website/src/components/Counter.vue
+++ b/website/src/components/Counter.vue
@@ -21,7 +21,8 @@
                       <a v-bind:href="extension.website">{{ extension.name }}</a>
                     </v-card-title>
                     <v-card-subtitle>
-                      <a v-bind:href="'https://hub.docker.com/r/' + extension.docker">{{ extension.identifier }}</a>
+                      <strong>Maintainer: </strong>
+                      <a v-bind:href="'mailto:' + maintainerEmail(extension)">{{ maintainerName(extension) }}</a>
                     </v-card-subtitle>
                   </v-col>
                   <v-slide-group class="mt-2" v-if="highestVersion(extension).filter_tags.length > 0">
@@ -58,5 +59,13 @@ const sections = computed(() => {
 function highestVersion(extension: RepositoryEntry) : Version {
   // Assumes versions are pre-sorted by semver, highest first
   return Object.values(extension.versions)[0];
+}
+
+function maintainerName(extension: RepositoryEntry) : string {
+  return highestVersion(extension)?.company?.name ?? 'Unknown';
+}
+
+function maintainerEmail(extension: RepositoryEntry) : string {
+  return highestVersion(extension)?.company?.email ?? '';
 }
 </script>

--- a/website/src/components/Counter.vue
+++ b/website/src/components/Counter.vue
@@ -13,7 +13,7 @@
             <v-card class="mx-auto" width="400px" outlined>
               <v-card-title>
                 <v-row no-gutters class="justify-center align-center">
-                  <v-avatar tile size="65" class="ma-2">
+                  <v-avatar tile size="65" class="ma-2 rounded-0">
                     <v-img :src="extension.extension_logo" />
                   </v-avatar>
                   <v-col>


### PR DESCRIPTION
- [x] fixes #48 (round icons -> square)
- Rusty made the fair point that the dockerhub image listing and the extension ID aren't particularly important to customers/users, and it's more helpful to highlight the maintainer
  - [x] add maintainer name
  - [x] link to maintainer email
  - [ ] tooltip with maintainer "about" info (I'm not sure how to do this, and it's likely not very important)

<img width="1229" alt="Screenshot 2023-04-29 at 3 46 47 am" src="https://user-images.githubusercontent.com/25898329/235219047-22b22cf8-d888-4fc1-824b-53eed98ed088.png">
