### PR TITLE
Minor extensions repository page description rewrite

### DIFF
--- a/repos/bluerobotics/cockpit/metadata.json
+++ b/repos/bluerobotics/cockpit/metadata.json
@@ -2,5 +2,5 @@
     "name": "Cockpit",
     "website": "https://github.com/bluerobotics/cockpit",
     "docker": "bluerobotics/cockpit",
-    "description": "Blue Robotics next generation control interface. Under development."
+    "description": "Blue Robotics' next generation control interface; under development"
 }

--- a/repos/jmrobotics/jm-connect/metadata.json
+++ b/repos/jmrobotics/jm-connect/metadata.json
@@ -2,5 +2,5 @@
     "name": "JM Connect",
     "website": "https://www.jmrobotics.no",
     "docker": "maphstra/jm-connect-blueos",
-    "description": "JM Connect Extension for BlueOs"
+    "description": "JM Connect Extension for BlueOS"
 }


### PR DESCRIPTION
Since none of the descriptions end with a full stop I thought the change in the `cockpit` file made more sense.