### PR TITLE
website: src: types: add `tool` type

### DIFF
--- a/website/src/types/manifest.ts
+++ b/website/src/types/manifest.ts
@@ -13,6 +13,7 @@ export enum ExtensionType {
     DEVICE_INTEGRATION = "device-integration",
     THEME = "theme",
     OTHER = "other",
+    TOOL = "tool",
     EXAMPLE = "example"
 }
 


### PR DESCRIPTION
This was forgotten in #63, and means extensions with the "tool" type don't show up in the [extensions gallery](https://docs.bluerobotics.com/BlueOS-Extensions-Repository).