### PR TITLE
consolidate.py: ignore extensions without valid versions

### DIFF
--- a/blueos_repository/consolidate.py
+++ b/blueos_repository/consolidate.py
@@ -210,7 +210,8 @@ class Consolidator:
             repository.versions = dict(
                 sorted(repository.versions.items(), key=lambda i: self.valid_semver(i[0]), reverse=True)  # type: ignore
             )
-            self.consolidated_data.append(repository)
+            if repository.versions:  # only include if there's at least one valid version
+                self.consolidated_data.append(repository)
 
         with open("manifest.json", "w", encoding="utf-8") as manifest_file:
             manifest_file.write(json.dumps(self.consolidated_data, indent=4, cls=EnhancedJSONEncoder))


### PR DESCRIPTION
Ideally such extensions shouldn't be accepted into the repository to start with, but good to have a fallback behaviour in case all SemVer compliant docker images get removed or something.

This should fix the website, which seemingly got broken by #74 without us realising.
@patrickelectric you should probably also upload a SemVer compliant version for your extension, or PR to remove it from the store.