### PR TITLE
repos: plc: fix typo and rename extension

### DIFF
--- a/repos/williangalvani/plc-diagnostics/metadata.json
+++ b/repos/williangalvani/plc-diagnostics/metadata.json
@@ -1,6 +1,6 @@
 {
-    "name": "PLC Diagnostics",
+    "name": "Tether Diagnostics",
     "website": "https://github.com/Williangalvani/plc-extension",
     "docker": "williangalvani/blueos-plc",
-    "description": "Diagnose issues with your thether"
+    "description": "Diagnose issues with your tether"
 }


### PR DESCRIPTION
That is the name we show in the sidebar, and I think it is more intuitive, too.