### PR TITLE
Update docker image platform check to allow arm64 images

### DIFF
--- a/blueos_repository/extension/extension.py
+++ b/blueos_repository/extension/extension.py
@@ -112,7 +112,7 @@ class Extension:
             bool: True if compatible, False otherwise.
         """
 
-        return bool(platform.os == "linux" and platform.architecture == "arm")
+        return bool(platform.os == "linux" and "arm" in platform.architecture)
 
     async def __extract_valid_embedded_digest(self, fetch: ManifestFetch) -> str:
         """


### PR DESCRIPTION
The current repo restricts ```arm64``` only docker images. This patch will allow arm64-only images that can be run on the (relatively newer) Raspberry Pi SoCs