### PR TITLE
website: Home.vue: include usage links for context

### DIFF
--- a/website/src/views/Home.vue
+++ b/website/src/views/Home.vue
@@ -1,4 +1,17 @@
 <template>
+  <v-card class="mx-auto" title="Usage">
+    <template v-slot:prepend>
+      <v-icon color="info" icon="mdi-information"></v-icon>
+    </template>
+    <v-card-text>
+      Extensions can be installed in <a href="https://blueos.cloud/">BlueOS</a>,
+      through the built in
+      <a
+        href="https://blueos.cloud/docs/latest/usage/advanced/#extensions-manager"
+        >Extensions Manager</a
+      >.
+    </v-card-text>
+  </v-card>
   <Counter />
 </template>
 


### PR DESCRIPTION
Some useful links, in case someone reaches the Extensions site without much context. 

I'm unsure whether the card I've added needs to be wrapped in an extra container or something to appear correctly - I'm intending for it to be an info bar/message at the top of the page 🤷‍♂️ 