### PR TITLE
blueos_repository: metadata: Fix docker image name and add multi-arch

### DIFF
--- a/repos/bluerobotics/navigator-webassistant/metadata.json
+++ b/repos/bluerobotics/navigator-webassistant/metadata.json
@@ -1,6 +1,6 @@
 {
     "name": "Navigator WebAssistant",
     "website": "https://github.com/RaulTrombin/blueos-navigator-web-assistant",
-    "docker": "raulelektron/blueos_navigator_webassistant",
+    "docker": "raulelektron/blueos-navigator-webassistant",
     "description": "Use navigator board through webservices."
 }


### PR DESCRIPTION
Quick-fix on extension name.

Integrated with the latest deploy-BlueOSExtension action.
![image](https://github.com/user-attachments/assets/54ba1a29-c381-44d1-ab27-450872793d45)
