### PR TITLE
blueos_repository:extension:models: Add education

### DIFF
--- a/blueos_repository/extension/models.py
+++ b/blueos_repository/extension/models.py
@@ -20,6 +20,7 @@ class ExtensionType(StrEnum):
     THEME = "theme"
     OTHER = "other"
     TOOL = "tool"
+    EDUCATION = "education"
 
 
 @dataclasses.dataclass


### PR DESCRIPTION
* Allows developers to tag their extensions as education type