### PR TITLE
blueos_repo:ext:consolidate: Change REPO_ROOT_URL

### DIFF
--- a/blueos_repository/consolidate.py
+++ b/blueos_repository/consolidate.py
@@ -17,7 +17,7 @@ MANIFEST_FILE = "manifest.json"
 
 MANIFEST_LOG = "manifest.log"
 
-REPO_ROOT_URL = "https://bluerobotics.github.io/BlueOS-Extensions-Repository/repos"
+REPO_ROOT_URL = "https://docs.bluerobotics.com/BlueOS-Extensions-Repository/repos"
 
 
 @dataclasses.dataclass


### PR DESCRIPTION
`github.io` is 301 to `docs.bluerobotics.com` and on the transition no CORS headers are present on the response causing frontend to not be able to use the responded data since it was tainted.