### PR TITLE
repos: update BlueOS-Community Extension websites

### DIFF
--- a/repos/bluerobotics/jupyter/metadata.json
+++ b/repos/bluerobotics/jupyter/metadata.json
@@ -1,6 +1,6 @@
 {
     "name": "Jupyter",
-    "website": "https://github.com/patrickelectric/blueos-jupyter",
+    "website": "https://github.com/BlueOS-Community/blueos-jupyter",
     "docker": "patrickelectric/blueos-jupyter",
     "description": "Code in Python directly in BlueOS"
 }

--- a/repos/bluerobotics/node-red/metadata.json
+++ b/repos/bluerobotics/node-red/metadata.json
@@ -1,6 +1,6 @@
 {
     "name": "Node-RED",
-    "website": "https://github.com/patrickelectric/blueos-node-red",
+    "website": "https://github.com/BlueOS-Community/blueos-node-red",
     "docker": "patrickelectric/blueos-node-red",
     "description": "Low-code development tool for custom functionality"
 }

--- a/repos/bluerobotics/openvscode/metadata.json
+++ b/repos/bluerobotics/openvscode/metadata.json
@@ -1,6 +1,6 @@
 {
     "name": "OpenVSCoder",
-    "website": "https://github.com/patrickelectric/blueos-code-server",
+    "website": "https://github.com/BlueOS-Community/blueos-code-server",
     "docker": "patrickelectric/blueos-openvscode",
     "description": "Edit and run code directly in BlueOS"
 }

--- a/repos/bluerobotics/ros/metadata.json
+++ b/repos/bluerobotics/ros/metadata.json
@@ -1,6 +1,6 @@
 {
     "name": "ROS",
-    "website": "https://github.com/patrickelectric/blueos-ros",
+    "website": "https://github.com/BlueOS-Community/blueos-ros",
     "docker": "patrickelectric/blueos-ros",
     "description": "Robot Operating System (ROS) extension for BlueOS"
 }

--- a/repos/bluerobotics/yacht/metadata.json
+++ b/repos/bluerobotics/yacht/metadata.json
@@ -1,6 +1,6 @@
 {
     "name": "Yacht",
-    "website": "https://github.com/patrickelectric/blueos-yacht",
+    "website": "https://github.com/BlueOS-Community/blueos-yacht",
     "docker": "patrickelectric/blueos-yacht",
     "description": "Easy to use container management utility"
 }

--- a/repos/rmackay9/opticalflow/metadata.json
+++ b/repos/rmackay9/opticalflow/metadata.json
@@ -1,6 +1,6 @@
 {
     "name": "OpticalFlow",
-    "website": "https://github.com/rmackay9/blueos-opticalflow",
+    "website": "https://github.com/BlueOS-Community/blueos-opticalflow",
     "docker": "rmackay9/blueos-opticalflow",
     "description": "Optical Flow using a camera gimbal connected via Ethernet"
 }

--- a/repos/rmackay9/precision-landing/metadata.json
+++ b/repos/rmackay9/precision-landing/metadata.json
@@ -1,6 +1,6 @@
 {
     "name": "Precision Landing",
-    "website": "https://github.com/rmackay9/blueos-precision-landing",
+    "website": "https://github.com/BlueOS-Community/blueos-precision-landing",
     "docker": "rmackay9/blueos-precision-landing",
     "description": "Precision landing on an AprilTag using a camera gimbal connected via Ethernet"
 }

--- a/repos/williangalvani/zerotier/metadata.json
+++ b/repos/williangalvani/zerotier/metadata.json
@@ -1,6 +1,6 @@
 {
     "name": "ZeroTier",
-    "website": "https://github.com/Williangalvani/ZeroTierOne",
+    "website": "https://github.com/BlueOS-Community/ZeroTierOne",
     "docker": "williangalvani/zerotier",
     "description": "Join a virtual network to operate your vehicle from anywhere"
 }


### PR DESCRIPTION
Realised a bunch of Extensions had ownership transferred to the BlueOS-Community organisation, but hadn't yet had their "website" links updated accordingly in the metadata.