### PR TITLE
Fix incorrect metadata extraction

### DIFF
--- a/blueos_repository/extension/extension.py
+++ b/blueos_repository/extension/extension.py
@@ -157,7 +157,7 @@ class Extension:
         links = json5.loads(labels.get("links", "{}"))
         filter_tags = json5.loads(labels.get("tags", "[]"))
 
-        docs_raw = links.pop("docs", links.pop("documentation", labels.get("docs", None)))
+        docs_link = links.pop("docs", links.pop("documentation", labels.get("docs", None)))
         company_raw = labels.get("company", None)
         permissions_raw = labels.get("permissions", None)
 
@@ -194,7 +194,7 @@ class Extension:
             extra_links=links,
             authors=json5.loads(authors),
             filter_tags=ExtensionVersion.validate_filter_tags(filter_tags),
-            docs=json5.loads(docs_raw) if docs_raw else None,
+            docs=docs_link,
             company=json5.loads(company_raw) if company_raw else None,
             permissions=json5.loads(permissions_raw) if permissions_raw else None,
             images=self.__extract_images_from_tag(version_tag),

--- a/blueos_repository/extension/extension.py
+++ b/blueos_repository/extension/extension.py
@@ -158,7 +158,7 @@ class Extension:
         filter_tags = json5.loads(labels.get("tags", "[]"))
 
         docs_link = links.pop("docs", links.pop("documentation", labels.get("docs", None)))
-        company_raw = labels.get("company", None)
+        company_raw = labels.get("company", labels.get("maintainer", None))
         permissions_raw = labels.get("permissions", None)
 
         readme = labels.get("readme", None)


### PR DESCRIPTION
The docs URL is currently being parsed as json5, which doesn't make sense, and can break Extension registration for Extensions that specify it.

---

As something of a side note, we've specified for a long time that the `company` label is expected to be replaced by `maintainer`. Removing support for `company` would be a breaking change, but I've added a patch here to at least allow users to specify `maintainer` instead, if that's what they prefer.