### PR TITLE
SITL Manager: Describe the simulated battery pack and saved presets

### DIFF
--- a/repos/armanzoli/sitl-manager/metadata.json
+++ b/repos/armanzoli/sitl-manager/metadata.json
@@ -2,5 +2,5 @@
   "name": "SITL Manager",
   "website": "https://github.com/ArturoManzoli/blueos-sitl-manager",
   "docker": "armanzoli/blueos-sitl-manager",
-  "description": "Configure SITL vehicle type, ambient conditions, and spawn location. Spawn location needs BlueOS 1.5.0-beta.39+."
+  "description": "Configure SITL vehicle type, ambient conditions, spawn location and a simulated battery pack, saving any of them as presets. Spawn location needs BlueOS 1.5.0-beta.39+."
 }


### PR DESCRIPTION
- SITL Manager 0.3.0 adds a simulated battery pack whose voltage, current and charge reach Cockpit through the autopilot's own monitor, and lets ambient conditions and spawn locations be saved as presets
- Store card still described only vehicle type, ambient conditions and spawn location
- Versioned data is unchanged: 0.3.0 comes from the Docker Hub tag's own labels